### PR TITLE
Add build and publish workflow to publish to npm registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Build and Publish
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build package
+        run: npm run build
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sanity Plugin Inline SVG Input [![npm version](https://badge.fury.io/js/@focus-reactive%2Fsanity-plugin-inline-svg-input.svg)](https://badge.fury.io/js/@focus-reactive%2Fsanity-plugin-inline-svg-input) [![Sanity Exchange](https://img.shields.io/badge/sanity-exchange-green)](https://www.sanity.io/plugins/sanity-plugin-inline-svg-input)
+# Sanity Plugin Inline SVG Input [![npm version](https://badge.fury.io/js/@starefossen%2Fsanity-plugin-inline-svg-input.svg)](https://badge.fury.io/js/@starefossen%2Fsanity-plugin-inline-svg-input) [![Sanity Exchange](https://img.shields.io/badge/sanity-exchange-green)](https://www.sanity.io/plugins/sanity-plugin-inline-svg-input)
 
 **Sanity Studio v3** plugin to upload and preview inline SVGs.
 
@@ -7,20 +7,20 @@
 - [SVG preview in arrays](#within-arrays)
 - [Customizable preview component](#custom-preview-component)
 
-![preview](https://raw.githubusercontent.com/focusreactive/sanity-plugin-inline-svg-input/main/docs/preview.gif)
+![preview](https://raw.githubusercontent.com/starefossen/sanity-plugin-inline-svg-input/main/docs/preview.gif)
 
 ## Installation
 
 ```sh
-npm install @focus-reactive/sanity-plugin-inline-svg-input
+npm install @starefossen/sanity-plugin-inline-svg-input
 ```
 
 ```sh
-yarn add @focus-reactive/sanity-plugin-inline-svg-input
+yarn add @starefossen/sanity-plugin-inline-svg-input
 ```
 
 ```sh
-pnpm add @focus-reactive/sanity-plugin-inline-svg-input
+pnpm add @starefossen/sanity-plugin-inline-svg-input
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ pnpm add @focus-reactive/sanity-plugin-inline-svg-input
 
 ```ts
 import { defineConfig } from 'sanity'
-import { inlineSvgInput } from '@focus-reactive/sanity-plugin-inline-svg-input'
+import { inlineSvgInput } from '@starefossen/sanity-plugin-inline-svg-input'
 
 export default defineConfig({
   // ...
@@ -64,7 +64,7 @@ The sections below describe how to preview your SVG within arrays, objects or yo
 Sanity offers a convenient way to preview arrays out of the box, but it only allows the use of the `image` type in `media`.
 To provide same functionality for SVGs, we provide a ready-to-use preview component that mimics the default array preview.
 
-![preview](https://raw.githubusercontent.com/focusreactive/sanity-plugin-inline-svg-input/main/docs/preview-list.jpg)
+![preview](https://raw.githubusercontent.com/starefossen/sanity-plugin-inline-svg-input/main/docs/preview-list.jpg)
 
 To preview your SVG in arrays, use the `InlineSvgPreviewItem` component.\
 It accepts the following props:
@@ -79,7 +79,7 @@ only what you need is to replace default preview component with `InlineSvgPrevie
 
 ```tsx
 import { defineType } from 'sanity'
-import { InlineSvgPreviewItem } from '@focus-reactive/sanity-plugin-inline-svg-input'
+import { InlineSvgPreviewItem } from '@starefossen/sanity-plugin-inline-svg-input'
 
 const IconsListItem = defineType({
   type: 'object',
@@ -130,7 +130,7 @@ It accepts the following props:
 - `value` [string] - inline SVG
 
 ```tsx
-import { InlineSvgPreviewComponent } from '@focus-reactive/sanity-plugin-inline-svg-input'
+import { InlineSvgPreviewComponent } from '@starefossen/sanity-plugin-inline-svg-input'
 
 export const PreviewComponent = ({ value }) => {
   return (
@@ -147,7 +147,7 @@ To customize the preview component, you can either:
 - Extend default styles with `styled-components`
 
 ```tsx
-import { InlineSvgPreviewComponent } from '@focus-reactive/sanity-plugin-inline-svg-input'
+import { InlineSvgPreviewComponent } from '@starefossen/sanity-plugin-inline-svg-input'
 import styled from 'styled-components'
 
 const StyledInlineSvg = styled(InlineSvgPreviewComponent)`
@@ -198,7 +198,7 @@ This project was created at **FocusReactive** - the [Sanity Partner Agency](http
 
 If you're looking for expertise in headless CMS, NextJS, or eCommerce, get in touch with **FocusReactive** today. Visit our website at [focusreactive.com](https://focusreactive.com/) to learn more about how we can help you accelerate your business growth.
 
-[![FocusReactive](https://raw.githubusercontent.com/focusreactive/sanity-plugin-inline-svg-input/main/docs/FR-logo-long.png)](https://focusreactive.com/sanity-expert-agency/)
+[![FocusReactive](https://raw.githubusercontent.com/starefossen/sanity-plugin-inline-svg-input/main/docs/FR-logo-long.png)](https://focusreactive.com/sanity-expert-agency/)
 ---
 
 _This project is licensed under the MIT License. © 2023 FocusReactive._

--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ Please run `npm publish --dry-run` to make sure that everything is ok before pub
 See [Testing a plugin in Sanity Studio](https://github.com/sanity-io/plugin-kit#testing-a-plugin-in-sanity-studio)
 for additional information.
 
+### Setting up NPM_TOKEN secret
+
+To publish the package to the npm registry using GitHub Actions, you need to set up the `NPM_TOKEN` secret in your GitHub repository settings. Follow these steps:
+
+1. Go to your repository on GitHub.
+2. Click on the `Settings` tab.
+3. In the left sidebar, click on `Secrets` and then `Actions`.
+4. Click the `New repository secret` button.
+5. In the `Name` field, enter `NPM_TOKEN`.
+6. In the `Value` field, enter your npm token. You can generate a new token from your npm account settings.
+7. Click the `Add secret` button.
+
+Once the `NPM_TOKEN` secret is set up, the GitHub Actions workflow will be able to use it to authenticate and publish the package to the npm registry.
+
 ## Credits
 
 This project was created at **FocusReactive** - the [Sanity Partner Agency](https://www.sanity.io/agency-partners/focusreactive). We specialize in helping clients beat the competition and accelerate business growth. With a deep expertise in headless CMS, NextJS, and eCommerce, we deliver cutting-edge solutions that prioritize your business goals.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   ],
   "homepage": "https://www.sanity.io/plugins/sanity-plugin-inline-svg-input",
   "bugs": {
-    "url": "https://github.com/focusreactive/sanity-plugin-inline-svg-input/issues"
+    "url": "https://github.com/starefossen/sanity-plugin-inline-svg-input/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/focusreactive/sanity-plugin-inline-svg-input.git"
+    "url": "git+ssh://git@github.com/starefossen/sanity-plugin-inline-svg-input.git"
   },
   "license": "MIT",
   "author": "Eugene Boruhov <eugene@focusreactive.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@focus-reactive/sanity-plugin-inline-svg-input",
+  "name": "@starefossen/sanity-plugin-inline-svg-input",
   "version": "1.1.0",
   "description": "Sanity plugin to upload and preview inline SVGs",
   "keywords": [


### PR DESCRIPTION
This pull request introduces several updates to the project, including repository migration, automation improvements, and documentation updates. Key changes include renaming the package to reflect the new repository ownership, adding Dependabot configuration for dependency updates, setting up a GitHub Actions workflow for building and publishing, and updating documentation to align with the new repository details.

### Repository migration and package renaming:
* Updated the package name from `@focus-reactive/sanity-plugin-inline-svg-input` to `@starefossen/sanity-plugin-inline-svg-input` in `package.json` and throughout the documentation. This includes changes to import paths, installation commands, and references to the repository. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R23) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R82) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R133) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R150)

* Updated repository URLs in `package.json` to point to the new GitHub repository `starefossen/sanity-plugin-inline-svg-input`.

### Automation improvements:
* Added Dependabot configuration in `.github/dependabot.yml` to automate dependency updates on a monthly schedule.

* Created a GitHub Actions workflow in `.github/workflows/publish.yml` for building and publishing the package to npm. This workflow includes steps for setting up Node.js, installing dependencies, building the package, and publishing it to the npm registry.

### Documentation updates:
* Updated image and badge URLs in `README.md` to reflect the new repository location. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R67) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L187-R201)

* Added a section in `README.md` explaining how to set up the `NPM_TOKEN` secret for publishing the package via GitHub Actions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Starefossen/sanity-plugin-inline-svg-input/pull/1?shareId=ec8917eb-c8db-46f0-9d93-8e4dfe35664b).