### PR TITLE
Update Node.js version to 22 in workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install
@@ -48,6 +48,6 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Update Node.js version in GitHub workflow to 22.

* Change `node-version` to `22` in the `Set up Node.js` steps in `.github/workflows/publish.yml`
* Replace `npm publish` command with `JS-DevTools/npm-publish@v3` action in `.github/workflows/publish.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Starefossen/sanity-plugin-inline-svg-input/pull/2?shareId=44b574a3-d605-4b2e-8bc4-2e09122b4169).