### PR TITLE
Set access=public for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: public

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ with default configuration for build & watch scripts.
 After running this command, you will see the instructions on how to add this plugin to your Sanity Studio in the terminal.
 
 `npm publish` - there is pre-publish script that prepares the plugin for publishing, you don't need to build it manually.
-Please run `npm publish --dry-run` to make sure that everything is ok before publishing.
+Please run `npm publish --dry-run` to make sure that everything is ok before publishing. When publishing, make sure to set `access=public`.
 
 See [Testing a plugin in Sanity Studio](https://github.com/sanity-io/plugin-kit#testing-a-plugin-in-sanity-studio)
 for additional information.


### PR DESCRIPTION
Add `access=public` for npm publish.

* Modify `.github/workflows/publish.yml` to include `access: public` under the `with` section of the `Publish to npm` step.
* Update `README.md` to mention setting `access=public` for npm publish in the publishing section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Starefossen/sanity-plugin-inline-svg-input/pull/3?shareId=5444696c-8055-4040-8bbd-ef23bb277a77).